### PR TITLE
Doctests should be indented by at least 4 spaces

### DIFF
--- a/lib/blitz_credo_checks/doctest_indent.ex
+++ b/lib/blitz_credo_checks/doctest_indent.ex
@@ -2,11 +2,13 @@ defmodule BlitzCredoChecks.DoctestIndent do
   use Credo.Check, base_priority: :high, category: :readability
 
   @moduledoc """
-  Doctest examples should be indented
+  Doctest examples should be indented by at least 4 spaces
 
   This allows ex_doc to render the example in a code block
   """
   @explanation [check: @moduledoc]
+
+  @regex ~r/(?<!    )iex>/
 
   @doc false
   @impl Credo.Check
@@ -19,7 +21,7 @@ defmodule BlitzCredoChecks.DoctestIndent do
   end
 
   defp traverse({:@, meta, [{:doc, _, [doc]}]} = ast, issues) when is_binary(doc) do
-    if String.contains?(doc, "\niex>") do
+    if Regex.match?(@regex, doc) do
       {ast, [meta[:line] | issues]}
     else
       {ast, issues}

--- a/test/blitz_credo_checks/doctest_indent_test.exs
+++ b/test/blitz_credo_checks/doctest_indent_test.exs
@@ -25,7 +25,7 @@ defmodule BlitzCredoChecks.DoctestIndentTest do
     |> assert_issue()
   end
 
-  test "accepts indented examples" do
+  test "rejects examples not indented enough" do
     """
     defmodule SomeApp.SomeContext.SomeModule do
 
@@ -36,6 +36,28 @@ defmodule BlitzCredoChecks.DoctestIndentTest do
 
         iex> String.to_atom("something")
         :something
+      \"\"\"
+      def some_function do
+        "This does nothing"
+      end
+    end
+    """
+    |> to_source_file()
+    |> DoctestIndent.run([])
+    |> assert_issue()
+  end
+
+  test "accepts examples indented by at least 4 spaces" do
+    """
+    defmodule SomeApp.SomeContext.SomeModule do
+
+      @doc \"\"\"
+      This is a description
+
+      ## Example
+
+          iex> String.to_atom("something")
+          :something
       \"\"\"
       def some_function do
         "This does nothing"


### PR DESCRIPTION
See here for markdown code blocks docs: https://www.markdownguide.org/basic-syntax#code-blocks

Technically, ex_doc does accept (and render) doctests and code-blocks indented by 2 spaces, but this is non-standard behavior and causes warnings in the markdown generator if there are unusual characters in the doctest. Enforcing (at least) 4 spaces solves the issue and follows the standard better.