### PR TITLE
Fix adjacent unpiped Enum functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix for UseStreamTest where it had a false positive on adjacent Enum functions that were not piped into each other
+
 ## v0.1.6 (2022-06-28)
 
 - allowed_modules option for ImproperImport can now take a list of atoms as well as a list of lists

--- a/lib/blitz_credo_checks/use_stream.ex
+++ b/lib/blitz_credo_checks/use_stream.ex
@@ -58,7 +58,10 @@ defmodule BlitzCredoChecks.UseStream do
     |> Enum.map(&issue_for(&1, issue_meta))
   end
 
-  defp traverse({:., _, [{:__aliases__, meta, [:Enum]}, func]} = ast, {add, remove})
+  defp traverse(
+         {:|>, _, [_, {{:., _, [{:__aliases__, meta, [:Enum]}, func]}, _, _}]} = ast,
+         {add, remove}
+       )
        when func in @stream_funcs do
     line = meta[:line]
 

--- a/test/blitz_credo_checks/use_stream_test.exs
+++ b/test/blitz_credo_checks/use_stream_test.exs
@@ -19,6 +19,20 @@ defmodule BlitzCredoChecks.UseStreamTest do
     |> refute_issues()
   end
 
+  test "doesn't reject adjacent unpiped enum functions" do
+    """
+    defmodule CredoSampleModule do
+      def function do
+        Enum.each([1, 2, 3], & &1 + 1)
+        Enum.each([1, 2, 3], & &1 * 2)
+      end
+    end
+    """
+    |> to_source_file()
+    |> UseStream.run([])
+    |> refute_issues()
+  end
+
   test "doesn't reject module attributes" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
The `UseStream` check rejects code with adjacent unpiped Enums, which appears to be incorrect behavior according to the description.

Added a test to verify this behavior.